### PR TITLE
Parse Postgres style casts

### DIFF
--- a/src/main/scala/com/criteo/vizatra/vizsql/dialects/postgresql/AST.scala
+++ b/src/main/scala/com/criteo/vizatra/vizsql/dialects/postgresql/AST.scala
@@ -1,0 +1,14 @@
+package com.criteo.vizatra.vizsql
+
+import Show._
+
+case object TimestampTzTypeLiteral extends TypeLiteral {
+  val mapType = TIMESTAMPTZ()
+  def show = keyword("timestamptz")
+}
+
+case object TimestampWithoutTimeZoneTypeLiteral extends TypeLiteral {
+  val mapType = TIMESTAMPWITHOUTTIMEZONE()
+  def show = keyword("timestamp without time zone")
+}
+

--- a/src/main/scala/com/criteo/vizatra/vizsql/dialects/postgresql/PostgresqlDialect.scala
+++ b/src/main/scala/com/criteo/vizatra/vizsql/dialects/postgresql/PostgresqlDialect.scala
@@ -2,7 +2,7 @@ package com.criteo.vizatra.vizsql
 
 object postgresql {
   implicit val dialect = new Dialect {
-    lazy val parser = new SQL99Parser
+    lazy val parser = new PostgreSQLParser
     lazy val functions = SQLFunction.standard orElse {
       case "date_trunc" => new SQLFunction2 {
         def result = { case (_, (_, t)) => Right(TIMESTAMP(nullable = t.nullable)) }

--- a/src/main/scala/com/criteo/vizatra/vizsql/dialects/postgresql/Types.scala
+++ b/src/main/scala/com/criteo/vizatra/vizsql/dialects/postgresql/Types.scala
@@ -1,0 +1,19 @@
+package com.criteo.vizatra.vizsql
+
+case class TIMESTAMPTZ(nullable: Boolean = false) extends Type {
+  def withNullable(nullable: Boolean = nullable) = this.copy(nullable).asInstanceOf[this.type]
+  def canBeCastTo(other: Type): Boolean = other match {
+    case TIMESTAMP(_) => true
+    case _ => false
+  }
+  def show = "timestamp"
+}
+
+case class TIMESTAMPWITHOUTTIMEZONE(nullable: Boolean = false) extends Type {
+  def withNullable(nullable: Boolean = nullable) = this.copy(nullable).asInstanceOf[this.type]
+  def canBeCastTo(other: Type): Boolean = other match {
+    case TIMESTAMP(_) => true
+    case _ => false
+  }
+  def show = "timestamp without time zone"
+}

--- a/src/main/scala/com/criteo/vizatra/vizsql/parsers/PostgreSQLParser.scala
+++ b/src/main/scala/com/criteo/vizatra/vizsql/parsers/PostgreSQLParser.scala
@@ -1,0 +1,44 @@
+package com.criteo.vizatra.vizsql
+
+import scala.util.parsing.combinator._
+import scala.util.parsing.combinator.lexical._
+import scala.util.parsing.combinator.syntactical._
+import scala.util.parsing.input.CharArrayReader.EofCh
+
+object PostgreSQLParser {
+  import SQL99Parser._
+
+  val postgresTypeMap: Map[String, TypeLiteral] = typeMap ++ Seq(
+    "timestamptz" -> TimestampTzTypeLiteral,
+    "timestamp without time zone" -> TimestampWithoutTimeZoneTypeLiteral
+  )
+}
+
+class PostgreSQLParser extends SQL99Parser {
+  override val typeMap = PostgreSQLParser.postgresTypeMap
+
+  val typeParser: PartialFunction[List[Elem], TypeLiteral] = { 
+    case ts: List[Elem] if typeMap.contains(ts.map(_.chars).mkString(" ").toLowerCase) => typeMap(ts.map(_.chars).mkString(" ").toLowerCase)
+  }
+
+  lazy val word = elem("ident", _.chars.forall(Character.isLetterOrDigit(_)))
+
+  override lazy val typeLiteral: Parser[TypeLiteral] =
+    rep1(word) ^? typeParser
+
+  override lazy val cast =
+    ("cast" ~ "(") ~> expr ~ ("as" ~> typeLiteral <~ ")") ^^ { case e ~ t => CastExpression(e, t) } |
+    expr ~ ("::" ~> typeLiteral) ^^ { case e ~ t => CastExpression(e, t) } 
+
+  override lazy val simpleExpr = (_: Parser[Expression]) =>
+    (cast
+    | literal                ^^ LiteralExpression
+    | function
+    | countStar
+    | caseWhen
+    | column                 ^^ ColumnExpression
+    | "(" ~> select <~ ")"   ^^ SubSelectExpression
+    | "(" ~> expr <~ ")"     ^^ ParenthesedExpression
+    | expressionPlaceholder
+    )
+}

--- a/src/main/scala/com/criteo/vizatra/vizsql/parsers/SQL99Parser.scala
+++ b/src/main/scala/com/criteo/vizatra/vizsql/parsers/SQL99Parser.scala
@@ -29,8 +29,10 @@ object SQL99Parser {
     "=", "{", "}",
     "^", "??(", "??)",
     "<>", ">=", "<=",
-    "||", "->", "=>"
+    "||", "->", "=>",
+    "::"
   )
+
   val comparisonOperators = Set("=", "<>", "<", ">", ">=", "<=")
 
   val likeOperators = Set("like")

--- a/src/test/scala/com/criteo/vizatra/vizsql/postgres/PostgreSQLParserSpec.scala
+++ b/src/test/scala/com/criteo/vizatra/vizsql/postgres/PostgreSQLParserSpec.scala
@@ -1,0 +1,51 @@
+package com.criteo.vizatra.vizsql
+
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.{Matchers, EitherValues, PropSpec}
+
+class PostgreSQLParserSpec extends PropSpec with Matchers with EitherValues with TableDrivenPropertyChecks {
+
+  val validPostgreSQLSelectStatements = TableDrivenPropertyChecks.Table(
+    ("SQL", "Expected AST"),
+    ("""select CAST(12 as timestamptz)""", SimpleSelect(
+      projections = List(
+        ExpressionProjection(
+          CastExpression(
+            from = LiteralExpression(IntegerLiteral(12)),
+            to = TimestampTzTypeLiteral
+          )
+        )
+      )
+    )),
+    ("""select CAST(12 as timestamp without time zone)""", SimpleSelect(
+      projections = List(
+        ExpressionProjection(
+          CastExpression(
+            from = LiteralExpression(IntegerLiteral(12)),
+            to = TimestampWithoutTimeZoneTypeLiteral
+          )
+        )
+      )
+    )),
+    ("""select 15::timestamptz""", SimpleSelect(
+      projections = List(
+        ExpressionProjection(
+          CastExpression(
+            from = LiteralExpression(IntegerLiteral(15)),
+            to = TimestampTzTypeLiteral
+          )
+        )
+      )
+    ))
+  )
+
+  // --
+
+  property("parse to correct types") {
+    forAll(validPostgreSQLSelectStatements) {
+      case (sql, expectedAst) =>
+        (new PostgreSQLParser).parseStatement(sql)
+          .fold(e => sys.error(s"\n\n${e.toString(sql)}\n"), identity) should be (expectedAst)
+    }
+  }
+}


### PR DESCRIPTION
@reverbdotcom/data-dev @ashiiish 

Opening this up for some comment.  The overarching idea here is that we could take advantage of true SQL parsing for a number of benefits:

a) We could statically analyze new ETL queries for syntax errors and some logic errors even before needing to integration test it
b) Rather than force explicit listing of the columns in the ETL apps, they could be inferred with their types from the SQL itself
c) It would help motivate us to template-ize the queries we have and write more automated verifications

Despite the small size of the PR this code will probably look odd.  The strategy used by the library I forked is combinatorial parsing.  This article gives some overview of how it works: http://enear.github.io/2016/03/31/parser-combinators/.  A very in depth treatment can be found here: http://www.cs.nott.ac.uk/~pszgmh/monparsing.pdf.

The main challenges here were getting the parser to recognize multi-word types like `timestamp without time zone` as well as the shorthand syntax for casting, `SELECT foo::integer` instead of `SELECT CAST(foo as integer)`.  There would be a bit more work necessary to support all of the Postgres types we use, as well as types that themselves can be parameterized like `timestamptz at time zone 'America/Chicago'`.

